### PR TITLE
fix: change getUserType for jwtAuthorizer to retrieve role correctly

### DIFF
--- a/jwtAuthorizer/src/app/eventHandler.js
+++ b/jwtAuthorizer/src/app/eventHandler.js
@@ -55,7 +55,7 @@ function getUserType(token) {
     if (!token.organization) {
         return 'PF';
     }
-    if (token.organization && token.organization.roles[0]?.role.startsWith('pg')) {
+    if (token.organization && token.organization.role.startsWith('pg')) {
         return 'PG';
     }
     if (token.organization) {

--- a/jwtAuthorizer/src/app/eventHandler.js
+++ b/jwtAuthorizer/src/app/eventHandler.js
@@ -55,7 +55,7 @@ function getUserType(token) {
     if (!token.organization) {
         return 'PF';
     }
-    if (token.organization && token.organization.role.startsWith('pg')) {
+    if (token.organization && token.organization.role?.startsWith('pg')) {
         return 'PG';
     }
     if (token.organization) {

--- a/jwtAuthorizer/src/app/eventHandler.js
+++ b/jwtAuthorizer/src/app/eventHandler.js
@@ -55,7 +55,7 @@ function getUserType(token) {
     if (!token.organization) {
         return 'PF';
     }
-    if (token.organization && token.organization.role?.startsWith('pg')) {
+    if (token.organization && token.organization.role?.startsWith('pg-')) {
         return 'PG';
     }
     if (token.organization) {


### PR DESCRIPTION
### Description

Change getUserType for jwtAuthorizer to retrieve role instead of roles[0].role.
Should remove error when jwtAuthorizer is called for pa users.