### PR TITLE
fix(pn-8716): add check after decoding JWT token

### DIFF
--- a/apikeyAuthorizerV2/src/app/validation.js
+++ b/apikeyAuthorizerV2/src/app/validation.js
@@ -20,7 +20,8 @@ async function validation(jwtToken) {
 }
 
 async function jwtValidator(jwtToken) {
-  const token = jsonwebtoken.decode(jwtToken, { complete: true });
+  const token = decodeToken(jwtToken);
+
   const keyId = token.header.kid;
   const tokenHeader = token.header;
   validateTokenHeader(tokenHeader);
@@ -78,6 +79,24 @@ function findKey(jwks, keyId) {
   }
 
   throw new ValidationException("Public key not found");
+}
+
+/**
+ * Decode a string representation of JWT token into a {@link jsonwebtoken.Jwt} object.
+ * If input string is does not comply with JWT structure then throw {@link ValidationException} error.
+ * 
+ * @param {string} jwtToken 
+ * @returns decoded token
+ */
+function decodeToken(jwtToken) {
+
+  const decodedToken = jsonwebtoken.decode(jwtToken, { complete: true });
+
+  if (!decodedToken) {
+    throw new ValidationException("Unable to decode input JWT string");
+  }
+
+  return decodedToken;
 }
 
 function validateTokenHeader(tokenHeader) {

--- a/apikeyAuthorizerV2/src/test/validation.test.js
+++ b/apikeyAuthorizerV2/src/test/validation.test.js
@@ -64,6 +64,12 @@ describe("test validation", () => {
     );
   });
 
+  it("test the token validation - Invalid token structure", async () => {
+    await expect(
+      validation("eyJ0eXAiOiJhdCtqd3QiLCJhbGciOiJSUzI1NiIsInVzZSI6InNpZyIsImtpZCI6IjMyZDhhMzIxLTE1NjgtNDRmNS05NTU4LWE5MDcyZjUxOWQyZCJ9")
+    ).to.be.rejectedWith(ValidationException, "Unable to decode input JWT string");
+  });
+
   it("test the token validation - Invalid token Type", async () => {
     await expect(
       validation(


### PR DESCRIPTION
## Issue Summary
The apiKeyAuthorizerV2.validate() method does not check the correctness of decoded token.

## Solution Description
Implemented decodeToken method that receives a string and decodes it to a JWT Token structured object.
If the input string does not comply with the standard JWT Token structure then the function throws a ValidationException.

Implemented unit test to verify the behavior above.