### PR TITLE
feature/PN-9110

### DIFF
--- a/jwtAuthorizer/package-lock.json
+++ b/jwtAuthorizer/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "aws-sdk-client-mock": "^3.0.0",
         "chai": "^4.3.6",
+        "chai-as-promised": "^7.1.1",
         "lambda-tester": "^4.0.1",
         "mocha": "^9.2.2",
         "mocha-lcov-reporter": "^1.3.0",
@@ -1948,6 +1949,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {

--- a/jwtAuthorizer/package.json
+++ b/jwtAuthorizer/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
     "lambda-tester": "^4.0.1",
     "aws-sdk-client-mock": "^3.0.0",
     "mocha": "^9.2.2",

--- a/jwtAuthorizer/src/app/validation.js
+++ b/jwtAuthorizer/src/app/validation.js
@@ -44,7 +44,7 @@ async function jwtValidator(jwtToken) {
     jsonwebtoken.verify(jwtToken, publicKeyPem);
   } catch (err) {
     console.warn("Validation error ", err);
-    throw new ValidationException(err.message);
+    throw new ValidationException(JSON.stringify(err));
   }
   console.log("success!");
   return token.payload;

--- a/jwtAuthorizer/src/app/validation.js
+++ b/jwtAuthorizer/src/app/validation.js
@@ -17,7 +17,8 @@ async function validation(jwtToken) {
 }
 
 async function jwtValidator(jwtToken) {
-  const token = jsonwebtoken.decode(jwtToken, { complete: true });
+  const token = decodeToken(jwtToken);
+  
   console.log("token ", token);
   const keyId = token.header.kid;
   console.debug("header keyId ", keyId);
@@ -72,6 +73,24 @@ function searchInCache(keyId) {
   } else {
     return null;
   }
+}
+
+/**
+ * Decode a string representation of JWT token into a {@link jsonwebtoken.Jwt} object.
+ * If input string is does not comply with JWT structure then throw {@link ValidationException} error.
+ * 
+ * @param {string} jwtToken 
+ * @returns decoded token
+ */
+function decodeToken(jwtToken) {
+
+  const decodedToken = jsonwebtoken.decode(jwtToken, { complete: true });
+
+  if (!decodedToken) {
+    throw new ValidationException("Unable to decode input JWT string");
+  }
+
+  return decodedToken;
 }
 
 module.exports = { validation };

--- a/jwtAuthorizer/src/test/validation.test.js
+++ b/jwtAuthorizer/src/test/validation.test.js
@@ -1,0 +1,75 @@
+const chaiAsPromised = require("chai-as-promised");
+const chai = require("chai");
+
+const { mockClient } = require("aws-sdk-client-mock");
+const { KMSClient, GetPublicKeyCommand } = require("@aws-sdk/client-kms");
+
+const { validation } = require("../app/validation");
+const ValidationException = require("../app/exception/validationException");
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe("test validation", () => {
+  let kmsClientMock;
+
+  before(() => {
+    kmsClientMock = mockClient(KMSClient);
+    kmsClientMock.on(GetPublicKeyCommand).resolves({
+      PublicKey: new Uint8Array([
+        48, 130, 1, 34, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 1, 5, 0,
+        3, 130, 1, 15, 0, 48, 130, 1, 10, 2, 130, 1, 1, 0, 157, 34, 97, 186, 80,
+        41, 131, 250, 205, 0, 88, 200, 66, 112, 98, 111, 55, 218, 63, 131, 134,
+        61, 166, 109, 54, 234, 139, 118, 36, 38, 56, 76, 245, 226, 8, 110, 194,
+        98, 208, 252, 119, 14, 123, 172, 87, 226, 38, 7, 191, 219, 199, 39, 187,
+        111, 102, 109, 48, 27, 68, 63, 164, 241, 29, 135, 233, 218, 128, 146,
+        231, 141, 246, 228, 186, 36, 84, 56, 13, 230, 44, 199, 162, 137, 139,
+        184, 26, 91, 73, 87, 56, 196, 199, 154, 127, 97, 165, 29, 25, 114, 219,
+        78, 126, 72, 254, 172, 166, 0, 126, 254, 106, 250, 229, 14, 191, 101,
+        191, 196, 122, 202, 202, 77, 167, 188, 182, 96, 247, 189, 228, 232, 236,
+        28, 115, 133, 114, 4, 150, 152, 32, 229, 85, 203, 228, 136, 17, 220,
+        161, 57, 229, 234, 62, 100, 81, 64, 165, 49, 124, 215, 170, 236, 105,
+        91, 142, 98, 189, 74, 80, 108, 141, 255, 119, 59, 109, 233, 51, 18, 32,
+        53, 236, 96, 252, 141, 58, 61, 113, 30, 184, 224, 35, 205, 183, 227, 37,
+        194, 82, 16, 145, 191, 232, 237, 1, 126, 223, 251, 100, 145, 252, 55,
+        225, 253, 189, 86, 40, 193, 14, 181, 74, 53, 42, 245, 199, 212, 166,
+        249, 179, 219, 57, 85, 167, 98, 204, 211, 118, 146, 18, 185, 10, 54,
+        162, 173, 187, 38, 88, 237, 100, 37, 151, 2, 74, 186, 58, 241, 229, 222,
+        109, 198, 251, 29, 2, 3, 1, 0, 1,
+      ]),
+    });
+  });
+
+  after(() => {
+    kmsClientMock.reset();
+  });
+
+  it("validation without authorization token", async () => {
+    await expect(validation(null)).to.be.rejectedWith(
+        ValidationException,
+        "token is not valid"
+    );
+  });
+
+  it("validation with expired JWT token", async () => {
+    await expect(
+        validation(
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Imh1Yi1zcGlkLWxvZ2luLXRlc3QifQ.eyJlbWFpbCI6ImluZm9AYWdpZC5nb3YuaXQiLCJmYW1pbHlfbmFtZSI6IlJvc3NpIiwiZmlzY2FsX251bWJlciI6IkdETk5XQTEySDgxWTg3NEYiLCJtb2JpbGVfcGhvbmUiOiIzMzMzMzMzMzQiLCJuYW1lIjoiTWFyaW8iLCJmcm9tX2FhIjpmYWxzZSwidWlkIjoiZWQ4NGI4YzktNDQ0ZS00MTBkLTgwZDctY2ZhZDZhYTEyMDcwIiwibGV2ZWwiOiJMMiIsImlhdCI6MTY1MTc0NzY0NiwiZXhwIjoxNjUxNzUxMjQ2LCJhdWQiOiJwb3J0YWxlLXBmLWRldmVsb3AuZmUuZGV2LnBuLnBhZ29wYS5pdCIsImlzcyI6Imh0dHBzOi8vc3BpZC1odWItdGVzdC5kZXYucG4ucGFnb3BhLml0IiwianRpIjoiMDFHMkE2VjBCMTNCSE5DUEVaMzJTN0tRM1kifQ.EcnBt1ZHD8Or00SgAP528lY4GcInWv3JfvtTER7_ago9Ef_patWOF1V38OZoUxKzaUrc-dZM7bQMS1PsinCcACyjZdf3D0lWiesftbBGTc221waF9vs7XOyvc1ckFSf7Qx9a1xWUPKETSqrMD7yZl7dHrWnsGLq-X_B7SQWNqd-kPFhXaD12ZYqKSRlMg35XNv2Ww491QqlzferTMBzyzUVf5JMoRjiTixdOaX420ncbRcs1jk91wiGCEqj7bTlGhQ-WIPlCcJRkLgrnj4jx6RAF8ncylfJGcp4NrIKarP82wIBglgTGZHC5TRsQbO_jFakXC8yX3Cvu8eN_T_XgPg"
+        )
+    ).to.be.rejectedWith(
+        ValidationException, 
+        JSON.stringify({"name":"TokenExpiredError", "message":"jwt expired", "expiredAt":"2022-05-05T11:47:26.000Z"})
+    );
+  });
+
+  it("validation without signature in JWT token", async () => {
+    await expect(
+        validation(
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Imh1Yi1zcGlkLWxvZ2luLXRlc3QifQ.eyJlbWFpbCI6ImluZm9AYWdpZC5nb3YuaXQiLCJmYW1pbHlfbmFtZSI6IlJvc3NpIiwiZmlzY2FsX251bWJlciI6IkdETk5XQTEySDgxWTg3NEYiLCJtb2JpbGVfcGhvbmUiOiIzMzMzMzMzMzQiLCJuYW1lIjoiTWFyaW8iLCJmcm9tX2FhIjpmYWxzZSwidWlkIjoiZWQ4NGI4YzktNDQ0ZS00MTBkLTgwZDctY2ZhZDZhYTEyMDcwIiwibGV2ZWwiOiJMMiIsImlhdCI6MTY1MTc0NzY0NiwiZXhwIjoxNjUxNzUxMjQ2LCJhdWQiOiJwb3J0YWxlLXBmLWRldmVsb3AuZmUuZGV2LnBuLnBhZ29wYS5pdCIsImlzcyI6Imh0dHBzOi8vc3BpZC1odWItdGVzdC5kZXYucG4ucGFnb3BhLml0IiwianRpIjoiMDFHMkE2VjBCMTNCSE5DUEVaMzJTN0tRM1kifQ."
+        )
+    ).to.be.rejectedWith(
+        ValidationException, 
+        JSON.stringify({"name":"JsonWebTokenError", "message":"jwt signature is required"})
+    );
+  });
+});

--- a/jwtAuthorizer/src/test/validation.test.js
+++ b/jwtAuthorizer/src/test/validation.test.js
@@ -62,14 +62,9 @@ describe("test validation", () => {
     );
   });
 
-  it("validation without signature in JWT token", async () => {
+  it("validation token with invalid structure", async () => {
     await expect(
-        validation(
-            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Imh1Yi1zcGlkLWxvZ2luLXRlc3QifQ.eyJlbWFpbCI6ImluZm9AYWdpZC5nb3YuaXQiLCJmYW1pbHlfbmFtZSI6IlJvc3NpIiwiZmlzY2FsX251bWJlciI6IkdETk5XQTEySDgxWTg3NEYiLCJtb2JpbGVfcGhvbmUiOiIzMzMzMzMzMzQiLCJuYW1lIjoiTWFyaW8iLCJmcm9tX2FhIjpmYWxzZSwidWlkIjoiZWQ4NGI4YzktNDQ0ZS00MTBkLTgwZDctY2ZhZDZhYTEyMDcwIiwibGV2ZWwiOiJMMiIsImlhdCI6MTY1MTc0NzY0NiwiZXhwIjoxNjUxNzUxMjQ2LCJhdWQiOiJwb3J0YWxlLXBmLWRldmVsb3AuZmUuZGV2LnBuLnBhZ29wYS5pdCIsImlzcyI6Imh0dHBzOi8vc3BpZC1odWItdGVzdC5kZXYucG4ucGFnb3BhLml0IiwianRpIjoiMDFHMkE2VjBCMTNCSE5DUEVaMzJTN0tRM1kifQ."
-        )
-    ).to.be.rejectedWith(
-        ValidationException, 
-        JSON.stringify({"name":"JsonWebTokenError", "message":"jwt signature is required"})
-    );
+      validation("eyJ0eXAiOiJhdCtqd3QiLCJhbGciOiJSUzI1NiIsInVzZSI6InNpZyIsImtpZCI6IjMyZDhhMzIxLTE1NjgtNDRmNS05NTU4LWE5MDcyZjUxOWQyZCJ9")
+    ).to.be.rejectedWith(ValidationException, "Unable to decode input JWT string");
   });
 });


### PR DESCRIPTION
## Issue Summary

1. The **jwtAuthorizer** validation method logs only the message of the exception related to jwt token verify operation.
This behavior is related to the `JsonWebTokenError` exception class (thrown by `jsonwebtoken.verify()` method in case of errors) that is created with prototype pattern cloning the `Error` exception class of ES5; the Error class overrides `toString()` method showing only the name of the exception and the message but hiding all remaining information (e.g. the expiration time).

2. Moreover, the validation method does not check the correctness of decoded token and it may lead to bugs in the future (related to PN-8716).

## Solution Description

1. Added the serialization of entire `err` variable that is an instance of `JsonWebTokenError` using `JSON.serialize()` method
2. Implemented decodeToken method that receives a string and decodes it to a JWT Token structured object.
If the input string does not comply with the standard JWT Token structure then the function throws a ValidationException.

Implemented unit tests to verify the behaviors above.