### PR TITLE
feature(PN-20043): oidc: replace fetch with axios to enable X-Ray HTTP tracing

### DIFF
--- a/oidc/package-lock.json
+++ b/oidc/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "aws-xray-sdk-core": "^3.12.0",
+        "axios": "^1.16.1",
         "base64url": "^3.0.1",
         "bunyan": "^1.8.15",
         "jsonwebtoken": "^9.0.0",
@@ -3457,6 +3458,12 @@
         "node": "^4.7 || >=6.9 || >=7.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
@@ -3514,6 +3521,43 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -3833,6 +3877,19 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4083,6 +4140,18 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4123,7 +4192,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4188,6 +4256,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4220,6 +4297,20 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4297,6 +4388,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es6-error": {
@@ -4580,6 +4716,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4595,6 +4751,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fromentries": {
@@ -4640,6 +4812,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4660,6 +4841,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4668,6 +4873,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4702,6 +4920,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4743,6 +4973,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -4778,6 +5035,18 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hmac-drbg": {
@@ -5995,6 +6264,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6014,6 +6292,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -6831,6 +7130,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pure-rand": {

--- a/oidc/package.json
+++ b/oidc/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "aws-xray-sdk-core": "^3.12.0",
+    "axios": "^1.16.1",
     "base64url": "^3.0.1",
     "bunyan": "^1.8.15",
     "jsonwebtoken": "^9.0.0",

--- a/oidc/src/app/handlers/oidcToken/utils/AwsParameters.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/AwsParameters.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { retryWithDelay } from "../../../utils/Retry";
 import { retrieveEnvVariable } from "../../../config";
 
@@ -63,21 +64,18 @@ const fetchAwsParameter = async (
 
   const url = `http://localhost:2773/${endpoint}`;
 
-  const response = await fetch(url, {
-    headers: {
-      "X-Aws-Parameters-Secrets-Token": sessionToken,
-    },
+  const response = await axios.get(url, {
+    headers: { "X-Aws-Parameters-Secrets-Token": sessionToken },
+  }).catch((err: any) => {
+    if (err?.response) {
+      throw new Error(
+        `Failed to fetch ${isSecret ? "secret" : "parameter"} "${name}": ${err.response.status} ${err.response.statusText}`
+      );
+    }
+    throw err;
   });
 
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch ${isSecret ? "secret" : "parameter"} "${name}": ${
-        response.status
-      } ${response.statusText}`
-    );
-  }
-
-  const data = await response.json();
+  const data = response.data;
 
   if (isSecret) {
     return data.SecretString || JSON.stringify(data.SecretBinary);

--- a/oidc/src/app/handlers/oidcToken/utils/EmdIntegrationClient.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/EmdIntegrationClient.ts
@@ -1,14 +1,13 @@
 import AWSXRay from "aws-xray-sdk-core";
 import http from "http";
 import https from "https";
+import axios from "axios";
 
 import { GetRetrievalPayloadResponse } from "../models/Source";
 import { retrieveEnvVariable } from "../../../config";
 
 AWSXRay.captureHTTPsGlobal(http);
 AWSXRay.captureHTTPsGlobal(https);
-
-import axios from "axios";
 
 /**
  * Retrieves the payload data for a given retrieval ID from the pn-emd-integration service.

--- a/oidc/src/app/handlers/oidcToken/utils/EmdIntegrationClient.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/EmdIntegrationClient.ts
@@ -8,6 +8,8 @@ import { retrieveEnvVariable } from "../../../config";
 AWSXRay.captureHTTPsGlobal(http);
 AWSXRay.captureHTTPsGlobal(https);
 
+import axios from "axios";
+
 /**
  * Retrieves the payload data for a given retrieval ID from the pn-emd-integration service.
  *
@@ -31,19 +33,11 @@ export const getRetrievalPayload = async (
   );
 
   try {
-    const response = await fetch(pnEmdIntegrationUrl, {
-      method: "GET",
-      headers: {
-        "Content-Type": "text/plain",
-      },
-      signal: AbortSignal.timeout(2000),
+    const response = await axios.get<GetRetrievalPayloadResponse>(pnEmdIntegrationUrl, {
+      headers: { "Content-Type": "text/plain" },
+      timeout: 2000,
     });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    return await response.json();
+    return response.data;
   } catch (err) {
     console.error("External service pn-emd-integration returned errors", {
       error: err,

--- a/oidc/src/app/handlers/oidcToken/utils/Jwks/JwksRetriever.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/Jwks/JwksRetriever.ts
@@ -1,14 +1,14 @@
 import AWSXRay from "aws-xray-sdk-core";
 import http from "http";
 import https from "https";
+import axios from "axios";
+
 import { retryWithDelay } from "../../../../utils/Retry";
 import { retrieveEnvVariable } from "../../../../config";
 import { JWKS } from "../../models/Jwks";
 
 AWSXRay.captureHTTPsGlobal(http);
 AWSXRay.captureHTTPsGlobal(https);
-
-import axios from "axios";
 
 const DEFAULT_TIMEOUT = 2000;
 const RETRY_DELAY = 1000;

--- a/oidc/src/app/handlers/oidcToken/utils/Jwks/JwksRetriever.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/Jwks/JwksRetriever.ts
@@ -1,13 +1,14 @@
 import AWSXRay from "aws-xray-sdk-core";
 import http from "http";
 import https from "https";
-
 import { retryWithDelay } from "../../../../utils/Retry";
 import { retrieveEnvVariable } from "../../../../config";
 import { JWKS } from "../../models/Jwks";
 
 AWSXRay.captureHTTPsGlobal(http);
 AWSXRay.captureHTTPsGlobal(https);
+
+import axios from "axios";
 
 const DEFAULT_TIMEOUT = 2000;
 const RETRY_DELAY = 1000;
@@ -22,20 +23,10 @@ async function innerGetJwks(): Promise<JWKS> {
 
   console.info("Fetching JWKS from:", jwksEndpoint);
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
-
   try {
-    const response = await fetch(jwksEndpoint, { signal: controller.signal });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
-    }
-
-    return await response.json();
+    const response = await axios.get<JWKS>(jwksEndpoint, { timeout: DEFAULT_TIMEOUT });
+    return response.data;
   } catch (error) {
-    clearTimeout(timeoutId);
     console.warn("Error fetching JWKS:", error);
     throw new Error("Error in get pub key");
   }

--- a/oidc/src/app/handlers/oidcToken/utils/OneIdentity.ts
+++ b/oidc/src/app/handlers/oidcToken/utils/OneIdentity.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { ValidationException } from "../../../exception/validationException";
 import { OneIdentityAwsSecretObject } from "../../../models/Aws";
 import { retrieveEnvVariable } from "../../../config";
@@ -37,28 +38,27 @@ export const exchangeOneIdentityCode = async ({
     redirect_uri: redirectUri,
   });
 
-  const response = await fetch(`${oneIdentityBaseUrl}/oidc/token`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${credentials}`,
-    },
-    body: body.toString(),
-  });
-
-  if (!response.ok) {
-    const responseBody = await response.text();
-    const errorMessage = `Error during code exchange with OneIdentity: ${responseBody}`;
-
-    if (response.status === 400) {
-      throw new ValidationException(errorMessage);
+  try {
+    const response = await axios.post<OIExchangeCodeResponse>(
+      `${oneIdentityBaseUrl}/oidc/token`,
+      body.toString(),
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${credentials}`,
+        },
+      }
+    );
+    console.info("One Identity Code exchanged successfully");
+    return response.data;
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response) {
+      const errorMessage = `Error during code exchange with OneIdentity: ${err.response.data}`;
+      if (err.response.status === 400) {
+        throw new ValidationException(errorMessage);
+      }
+      throw new Error(errorMessage);
     }
-
-    throw new Error(errorMessage);
+    throw err;
   }
-
-  console.info("One Identity Code exchanged successfully");
-
-  const data: OIExchangeCodeResponse = await response.json();
-  return data;
 };

--- a/oidc/src/test/utils/AwsParameters.test.ts
+++ b/oidc/src/test/utils/AwsParameters.test.ts
@@ -1,15 +1,20 @@
+import axios from "axios";
 import {
   getAWSParameterStore,
   getAWSSecret,
 } from "../../app/handlers/oidcToken/utils/AwsParameters";
 import { setupEnv } from "../test.utils";
 
-global.fetch = jest.fn();
-
-// Mock retryWithDelay to call the function immediately without delay
+jest.mock("axios");
 jest.mock("../../app/utils/Retry.ts", () => ({
   retryWithDelay: jest.fn((fn) => fn()),
 }));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const axiosError = (status: number, statusText: string) => ({
+  response: { status, statusText },
+});
 
 describe("AwsParameters", () => {
   beforeEach(() => {
@@ -18,15 +23,14 @@ describe("AwsParameters", () => {
   });
 
   it("should fetch SSM parameter successfully", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ Parameter: { Value: "param-value" } }),
+    mockedAxios.get.mockResolvedValue({
+      data: { Parameter: { Value: "param-value" } },
     });
 
     const result = await getAWSParameterStore("/test/param");
 
     expect(result).toBe("param-value");
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(mockedAxios.get).toHaveBeenCalledWith(
       "http://localhost:2773/systemsmanager/parameters/get?name=%2Ftest%2Fparam",
       expect.objectContaining({
         headers: { "X-Aws-Parameters-Secrets-Token": "fake-session-token" },
@@ -35,15 +39,14 @@ describe("AwsParameters", () => {
   });
 
   it("should fetch secret successfully", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ SecretString: '{"secret-key":"my-secret-value"}' }),
+    mockedAxios.get.mockResolvedValue({
+      data: { SecretString: '{"secret-key":"my-secret-value"}' },
     });
 
     const result = await getAWSSecret("my-secret");
 
     expect(result).toEqual({ "secret-key": "my-secret-value" });
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(mockedAxios.get).toHaveBeenCalledWith(
       "http://localhost:2773/secretsmanager/get?secretId=my-secret",
       expect.objectContaining({
         headers: { "X-Aws-Parameters-Secrets-Token": "fake-session-token" },
@@ -52,11 +55,8 @@ describe("AwsParameters", () => {
   });
 
   it("should handle SecretBinary when SecretString is not present", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        SecretBinary: { key: "binary-value" },
-      }),
+    mockedAxios.get.mockResolvedValue({
+      data: { SecretBinary: { key: "binary-value" } },
     });
 
     const result = await getAWSSecret("my-secret");
@@ -73,11 +73,7 @@ describe("AwsParameters", () => {
   });
 
   it("should throw error when parameter fetch fails", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
+    mockedAxios.get.mockRejectedValue(axiosError(404, "Not Found"));
 
     await expect(getAWSParameterStore("/invalid/param")).rejects.toThrow(
       'Failed to fetch parameter "/invalid/param": 404 Not Found'
@@ -85,11 +81,7 @@ describe("AwsParameters", () => {
   });
 
   it("should throw error when secret fetch fails", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
+    mockedAxios.get.mockRejectedValue(axiosError(404, "Not Found"));
 
     await expect(getAWSSecret("/invalid/secret")).rejects.toThrow(
       'Failed to fetch secret "/invalid/secret": 404 Not Found'
@@ -97,9 +89,8 @@ describe("AwsParameters", () => {
   });
 
   it("should throw error when secret JSON parsing fails", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ SecretString: "invalid-json{" }),
+    mockedAxios.get.mockResolvedValue({
+      data: { SecretString: "invalid-json{" },
     });
 
     await expect(getAWSSecret("my-secret")).rejects.toThrow(
@@ -108,12 +99,10 @@ describe("AwsParameters", () => {
   });
 
   it("should handle non Error objects in JSON parsing failure", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ SecretString: "invalid-json{" }),
+    mockedAxios.get.mockResolvedValue({
+      data: { SecretString: "invalid-json{" },
     });
 
-    // Mock JSON.parse to throw a non Error object
     const originalParse = JSON.parse;
     JSON.parse = jest.fn(() => {
       throw "Generic error";

--- a/oidc/src/test/utils/EmdIntegrationClient.test.ts
+++ b/oidc/src/test/utils/EmdIntegrationClient.test.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { getRetrievalPayload } from "../../app/handlers/oidcToken/utils/EmdIntegrationClient";
 import {
   checkTppResponseMock,
@@ -5,7 +6,11 @@ import {
 } from "../__mock__/emdIntegration.mock";
 import { setupEnv } from "../test.utils";
 
-global.fetch = jest.fn();
+jest.mock("aws-xray-sdk-core", () => ({
+  captureHTTPsGlobal: jest.fn(),
+}));
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("EMD Integration Client tests", () => {
   beforeEach(() => {
@@ -14,27 +19,19 @@ describe("EMD Integration Client tests", () => {
   });
 
   it("should successfully get retrieval payload", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => checkTppResponseMock,
-    });
+    mockedAxios.get.mockResolvedValue({ data: checkTppResponseMock });
 
     const result = await getRetrievalPayload(retrievalIdMock);
 
     expect(result).toBe(checkTppResponseMock);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(mockedAxios.get).toHaveBeenCalledWith(
       `${process.env.PN_EMD_INTEGRATION_BASEURL}/emd-integration-private/token/check-tpp?retrievalId=${retrievalIdMock}`,
-      expect.objectContaining({
-        method: "GET",
-      })
+      expect.objectContaining({ timeout: 2000 })
     );
   });
 
   it("should throw an error if response is not ok", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      status: 500,
-    });
+    mockedAxios.get.mockRejectedValue(new Error("HTTP error! status: 500"));
 
     await expect(getRetrievalPayload(retrievalIdMock)).rejects.toThrow(
       "Failed to retrieve TPP payload"
@@ -42,9 +39,7 @@ describe("EMD Integration Client tests", () => {
   });
 
   it("should throw an error if fetch fails", async () => {
-    (global.fetch as jest.Mock).mockRejectedValue(
-      new Error("Error during check TPP")
-    );
+    mockedAxios.get.mockRejectedValue(new Error("Error during check TPP"));
 
     await expect(getRetrievalPayload(retrievalIdMock)).rejects.toThrow(
       "Failed to retrieve TPP payload"

--- a/oidc/src/test/utils/Jwks/JwksRetriever.test.ts
+++ b/oidc/src/test/utils/Jwks/JwksRetriever.test.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { getJwks } from "../../../app/handlers/oidcToken/utils/Jwks/JwksRetriever";
 import { mockJwksResponse } from "../../__mock__/jwks.mock";
 import { setupEnv } from "../../test.utils";
@@ -10,7 +11,8 @@ jest.mock("../../../app/utils/Retry", () => ({
   retryWithDelay: jest.fn((fn) => fn()),
 }));
 
-global.fetch = jest.fn();
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const mockJwksEndpoint = "https://uat.oneid.pagopa.it/oidc/keys";
 
@@ -22,30 +24,22 @@ describe("retrieverJwks", () => {
 
   describe("getJwks", () => {
     it("should successfully fetch and return JWKS", async () => {
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => mockJwksResponse,
-      });
+      mockedAxios.get.mockResolvedValueOnce({ data: mockJwksResponse });
 
       const result = await getJwks();
 
-      expect(fetch).toHaveBeenCalledWith(mockJwksEndpoint, {
-        signal: expect.any(AbortSignal),
+      expect(mockedAxios.get).toHaveBeenCalledWith(mockJwksEndpoint, {
+        timeout: 2000,
       });
       expect(result).toEqual(mockJwksResponse);
     });
 
     it("should throw error when fetch fails with HTTP error", async () => {
-      (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-      });
+      mockedAxios.get.mockRejectedValueOnce(new Error("Internal Server Error"));
 
       await expect(getJwks()).rejects.toThrow("Error in get pub key");
-      expect(fetch).toHaveBeenCalledWith(mockJwksEndpoint, {
-        signal: expect.any(AbortSignal),
+      expect(mockedAxios.get).toHaveBeenCalledWith(mockJwksEndpoint, {
+        timeout: 2000,
       });
     });
   });

--- a/oidc/src/test/utils/OneIdentity.test.ts
+++ b/oidc/src/test/utils/OneIdentity.test.ts
@@ -1,26 +1,26 @@
+import axios, { AxiosError } from "axios";
 import { ValidationException } from "../../app/exception/validationException";
 import { exchangeOneIdentityCode } from "../../app/handlers/oidcToken/utils/OneIdentity";
 import {
-    oneIdentityCredentialsMock,
-    oneIdentityExchangeCodeResponseMock,
+  oneIdentityCredentialsMock,
+  oneIdentityExchangeCodeResponseMock,
 } from "../__mock__/oneIdentity.mock";
 import { setupEnv } from "../test.utils";
 
 describe("One Identity tests", () => {
   const mockCode = "test_auth_code_123";
   const mockRedirectUri = "https://example.com/callback";
-
   const mockOneIdentityUrl = "https://uat.oneid.pagopa.it";
 
-  let fetchMock: jest.SpyInstance;
+  let postMock: jest.SpyInstance;
 
   beforeEach(() => {
     setupEnv();
-    fetchMock = jest.spyOn(global, "fetch").mockImplementation();
+    postMock = jest.spyOn(axios, "post").mockImplementation(jest.fn());
   });
 
   afterEach(() => {
-    fetchMock.mockRestore();
+    postMock.mockRestore();
   });
 
   it("should successfully exchange One Identity Code", async () => {
@@ -28,12 +28,7 @@ describe("One Identity tests", () => {
       `${oneIdentityCredentialsMock.oneIdentityClientId}:${oneIdentityCredentialsMock.oneIdentityClientSecret}`
     ).toString("base64");
 
-    const mockResponse = {
-      ok: true,
-      json: jest.fn().mockResolvedValue(oneIdentityExchangeCodeResponseMock),
-    };
-
-    fetchMock.mockResolvedValue(mockResponse);
+    postMock.mockResolvedValue({ data: oneIdentityExchangeCodeResponseMock });
 
     const result = await exchangeOneIdentityCode({
       code: mockCode,
@@ -43,30 +38,26 @@ describe("One Identity tests", () => {
 
     expect(result).toEqual(oneIdentityExchangeCodeResponseMock);
 
-    const fetchCall = fetchMock.mock.calls[0];
-    const [url, options] = fetchCall;
-    const bodyParams = new URLSearchParams(options.body);
+    const [url, body, config] = postMock.mock.calls[0] as [string, string, any];
+    const bodyParams = new URLSearchParams(body);
 
     expect(url).toBe(`${mockOneIdentityUrl}/oidc/token`);
-
-    expect(options.headers["Content-Type"]).toBe(
-      "application/x-www-form-urlencoded"
-    );
-    expect(options.headers.Authorization).toBe(`Basic ${expectedCredentials}`);
-
+    expect(config.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(config.headers.Authorization).toBe(`Basic ${expectedCredentials}`);
     expect(bodyParams.get("code")).toBe(mockCode);
     expect(bodyParams.get("grant_type")).toBe("authorization_code");
     expect(bodyParams.get("redirect_uri")).toBe(mockRedirectUri);
   });
 
   it("should throw ValidationException when response status is 400", async () => {
-    const mockResponse = {
-      ok: false,
-      status: 400,
-      statusText: "Bad Request",
-      text: jest.fn().mockResolvedValue("Error during code exchange"),
-    };
-    fetchMock.mockResolvedValue(mockResponse);
+    const error = new AxiosError(
+      "Bad Request",
+      "400",
+      undefined,
+      undefined,
+      { status: 400, statusText: "Bad Request", data: "Error during code exchange", headers: {}, config: {} as any }
+    );
+    postMock.mockRejectedValue(error);
 
     await expect(
       exchangeOneIdentityCode({
@@ -82,13 +73,14 @@ describe("One Identity tests", () => {
   });
 
   it("should throw generic Error when response status is not 400 (e.g., 500)", async () => {
-    const mockResponse = {
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      text: jest.fn().mockResolvedValue("Server error occurred"),
-    };
-    fetchMock.mockResolvedValue(mockResponse);
+    const error = new AxiosError(
+      "Internal Server Error",
+      "500",
+      undefined,
+      undefined,
+      { status: 500, statusText: "Internal Server Error", data: "Server error occurred", headers: {}, config: {} as any }
+    );
+    postMock.mockRejectedValue(error);
 
     await expect(
       exchangeOneIdentityCode({
@@ -101,6 +93,8 @@ describe("One Identity tests", () => {
         "Error during code exchange with OneIdentity: Server error occurred"
       )
     );
+
+    postMock.mockRejectedValue(error);
 
     await expect(
       exchangeOneIdentityCode({


### PR DESCRIPTION
Native fetch (Node.js 18+) uses `undici` internally and bypasses the http/https modules patched by `captureHTTPsGlobal`, making outbound HTTP calls invisible to `X-Ray`. Switching to axios restores tracing for calls to OneIdentity, pn-emd-integration and Parameter Store.