### PR TITLE
PN-19126: LollipopAutorizer - reso obbligatorio 'x-pagopa-lollipop-us…

### DIFF
--- a/lollipopAuthorizer/src/app/eventHandler.js
+++ b/lollipopAuthorizer/src/app/eventHandler.js
@@ -96,32 +96,38 @@ async function handleEvent(event) {
             return defaultDenyAllPolicy;
         }
 
-        if (!taxId) {
-            console.error("Header 'x-pagopa-cx-taxid' is missing. Denying access.");
+        if (!userId) {
+            console.error("Header 'x-pagopa-lollipop-user-id' is missing. Denying access.");
             return defaultDenyAllPolicy;
-        } else if (userId && taxId.toUpperCase() !== userId.toUpperCase()) {
-            console.error("Mismatch between taxId and userId.");
-            return defaultDenyAllPolicy;
-        } else {
-            console.info("Match found between taxId and userId");
-            try {
-              const cxId = await getCxId(taxId);
-              console.info("cxId", cxId);
-              // Generate IAM Policy
-              const contextMap = {
-                    resultCode: commandResult.resultCode || '',
-                    name: commandResult.name || '',
-                    familyName: commandResult.familyName || '',
-                    cxId: cxId,
-                    sourceChannelDetails: sourceDetails,
-              };
-              iamPolicy = await generateIAMPolicy(event.methodArn, contextMap );
-              console.log("IAM Policy generated", iamPolicy?.policyDocument?.Statement?.[0]?.Effect);
-              return iamPolicy;
-            } catch (err) {
-              console.error("Error generating IAM policy with error ", err);
-              return defaultDenyAllPolicy;
+        } 
+        
+        if (taxId) {
+            console.info("Header 'x-pagopa-cx-taxid' present");
+            if (userId.toUpperCase() !== taxId.toUpperCase()) {
+                console.error("Mismatch between taxId and userId.");
+                return defaultDenyAllPolicy;
+            } else {
+                console.info("Match found between taxId and userId");
             }
+        }
+        
+        try {
+          const cxId = await getCxId(userId);
+          console.info("cxId", cxId);
+          // Generate IAM Policy
+          const contextMap = {
+                resultCode: commandResult.resultCode || '',
+                name: commandResult.name || '',
+                familyName: commandResult.familyName || '',
+                cxId: cxId,
+                sourceChannelDetails: sourceDetails,
+          };
+          iamPolicy = await generateIAMPolicy(event.methodArn, contextMap );
+          console.log("IAM Policy generated", iamPolicy?.policyDocument?.Statement?.[0]?.Effect);
+          return iamPolicy;
+        } catch (err) {
+          console.error("Error generating IAM policy with error ", err);
+          return defaultDenyAllPolicy;
         }
 
     } catch (error) {

--- a/lollipopAuthorizer/src/test/eventHandler.test.js
+++ b/lollipopAuthorizer/src/test/eventHandler.test.js
@@ -48,7 +48,7 @@ describe('EventHandler - Test Suite', () => {
     it('dovrebbe restituire una policy ALLOW quando tutti i passaggi hanno successo', async () => {
         const mockEvent = {
             methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
-            headers: { 'x-pagopa-cx-taxid': 'TAX12345' }
+            headers: { 'x-pagopa-cx-taxid': 'TAX12345', 'x-pagopa-lollipop-user-id': 'TAX12345' }
         };
 
         const mockLollipopResult = {
@@ -82,7 +82,7 @@ describe('EventHandler - Test Suite', () => {
     it('dovrebbe restituire una policy DENY quando la validazione Lollipop fallisce', async () => {
         const mockEvent = {
             methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
-            headers: { 'x-pagopa-cx-taxid': 'TAX12345' }
+            headers: { 'x-pagopa-cx-taxid': 'TAX12345', 'x-pagopa-lollipop-user-id': 'TAX12345' }
         };
 
         stubs.validateLollipopAuthorizer.rejects(new Error('Validation failed'));
@@ -99,7 +99,7 @@ describe('EventHandler - Test Suite', () => {
     it('dovrebbe restituire una policy DENY quando getCxId fallisce', async () => {
         const mockEvent = {
             methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
-            headers: { 'x-pagopa-cx-taxid': 'TAX12345' }
+            headers: { 'x-pagopa-cx-taxid': 'TAX12345', 'x-pagopa-lollipop-user-id': 'TAX12345' }
         };
 
         const mockLollipopResult = { statusCode: 200, resultCode: 'SUCCESS' };
@@ -117,7 +117,7 @@ describe('EventHandler - Test Suite', () => {
         it('dovrebbe restituire una policy DENY quando generateIAMPolicy fallisce', async () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
-                headers: { 'x-pagopa-cx-taxid': 'TAX12345' }
+                headers: { 'x-pagopa-cx-taxid': 'TAX12345', 'x-pagopa-lollipop-user-id': 'TAX12345' }
             };
 
             const mockLollipopResult = { statusCode: 200, resultCode: 'SUCCESS' };
@@ -141,6 +141,84 @@ describe('EventHandler - Test Suite', () => {
 
         expect(result).to.deep.equal(defaultDenyAllPolicy);
         delete process.env.LOLLIPOP_BLOCK;
+    });
+
+    // TEST 6: TAXID FACOLTATIVO (PN-19126)
+    it('dovrebbe restituire una policy ALLOW quando taxId è assente ma userId è presente', async () => {
+        const mockEvent = {
+            methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
+            headers: { 'x-pagopa-lollipop-user-id': 'TAX12345' }
+        };
+
+        const mockLollipopResult = {
+            statusCode: 200,
+            resultCode: 'SUCCESS',
+            name: 'Mario',
+            familyName: 'Rossi'
+        };
+
+        const mockPolicy = { principalId: 'user', policyDocument: { Statement: [{ Effect: 'Allow' }] } };
+
+        stubs.validateLollipopAuthorizer.resolves(mockLollipopResult);
+        stubs.getCxId.resolves('CX-ID-999');
+        stubs.generateIAMPolicy.resolves(mockPolicy);
+
+        const result = await handleEvent(mockEvent);
+
+        expect(result).to.deep.equal(mockPolicy);
+        expect(stubs.getCxId.calledWith('TAX12345')).to.be.true;
+    });
+
+    // TEST 7: USERID OBBLIGATORIO (PN-19126)
+    it("dovrebbe restituire una policy DENY quando l'header 'x-pagopa-lollipop-user-id' è assente", async () => {
+        const mockEvent = {
+            methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
+            headers: { 'x-pagopa-cx-taxid': 'TAX12345' }
+        };
+
+        stubs.validateLollipopAuthorizer.resolves({ statusCode: 200, resultCode: 'SUCCESS' });
+
+        const result = await handleEvent(mockEvent);
+
+        expect(result).to.deep.equal(defaultDenyAllPolicy);
+        expect(stubs.getCxId.called).to.be.false;
+        expect(stubs.generateIAMPolicy.called).to.be.false;
+    });
+
+    // TEST 8: MISMATCH TAXID/USERID (PN-19126)
+    it('dovrebbe restituire una policy DENY quando taxId e userId non coincidono', async () => {
+        const mockEvent = {
+            methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
+            headers: { 'x-pagopa-cx-taxid': 'TAX12345', 'x-pagopa-lollipop-user-id': 'OTHER999' }
+        };
+
+        stubs.validateLollipopAuthorizer.resolves({ statusCode: 200, resultCode: 'SUCCESS' });
+
+        const result = await handleEvent(mockEvent);
+
+        expect(result).to.deep.equal(defaultDenyAllPolicy);
+        expect(stubs.getCxId.called).to.be.false;
+        expect(stubs.generateIAMPolicy.called).to.be.false;
+    });
+
+    // TEST 9: MATCH CASE-INSENSITIVE TAXID/USERID (PN-19126)
+    it('dovrebbe restituire una policy ALLOW quando taxId e userId coincidono con case diverso', async () => {
+        const mockEvent = {
+            methodArn: 'arn:aws:execute-api:region:account:api/stage/GET/path',
+            headers: { 'x-pagopa-cx-taxid': 'tax12345', 'x-pagopa-lollipop-user-id': 'TAX12345' }
+        };
+
+        const mockLollipopResult = { statusCode: 200, resultCode: 'SUCCESS' };
+        const mockPolicy = { principalId: 'user', policyDocument: { Statement: [{ Effect: 'Allow' }] } };
+
+        stubs.validateLollipopAuthorizer.resolves(mockLollipopResult);
+        stubs.getCxId.resolves('CX-ID-999');
+        stubs.generateIAMPolicy.resolves(mockPolicy);
+
+        const result = await handleEvent(mockEvent);
+
+        expect(result).to.deep.equal(mockPolicy);
+        expect(stubs.getCxId.calledWith('TAX12345')).to.be.true;
     });
 
     describe('effectiveBlock - override per-URL', () => {
@@ -185,7 +263,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/io-connector/send',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns({ substringURL: '/io-connector/', methods: ['POST'], URLpattern: '.*', blocking: true });
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 400, resultCode: 'VALIDATION_ERROR' });
@@ -201,7 +279,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/delivery/send',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns({ substringURL: '/delivery/', methods: ['POST'], URLpattern: '.*', blocking: false });
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 400, resultCode: 'VALIDATION_ERROR' });
@@ -219,7 +297,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/delivery/send',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns({ substringURL: '/delivery/', methods: ['POST'], URLpattern: '.*' });
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 400, resultCode: 'VALIDATION_ERROR' });
@@ -237,7 +315,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/unknown/endpoint',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.throws(new Error('MICROSERVICE_CONFIG_NOT_FOUND'));
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 400, resultCode: 'VALIDATION_ERROR' });
@@ -255,7 +333,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/unknown/endpoint',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns(null);
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 400, resultCode: 'VALIDATION_ERROR' });
@@ -273,7 +351,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/io-connector/send',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns({ substringURL: '/io-connector/', methods: ['POST'], URLpattern: '.*', blocking: true });
             stubsWithConfig.validateLollipopAuthorizer.resolves({ statusCode: 200, resultCode: 'SUCCESS' });
@@ -290,7 +368,7 @@ describe('EventHandler - Test Suite', () => {
             const mockEvent = {
                 methodArn: 'arn:aws:execute-api:region:account:api/stage/POST/path',
                 path: '/api/v1/io-connector/send',
-                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S' }
+                headers: { 'x-pagopa-cx-taxid': 'RSSMRA85T10A562S', 'x-pagopa-lollipop-user-id': 'RSSMRA85T10A562S' }
             };
             stubsWithConfig.findMicroserviceConfig.returns({ substringURL: '/io-connector/', methods: ['POST'], URLpattern: '.*', blocking: true });
             stubsWithConfig.validateLollipopAuthorizer.rejects(new Error('Unexpected error'));

--- a/lollipopAuthorizer/src/test/index.test.js
+++ b/lollipopAuthorizer/src/test/index.test.js
@@ -64,6 +64,7 @@ describe("index tests", function () {
       httpMethod: "GET",
       headers: {
         "x-pagopa-cx-taxid": taxId,
+        "x-pagopa-lollipop-user-id": taxId,
         "x-pagopa-lollipop-assertion-type": "SAML"
       },
       requestContext: {
@@ -111,6 +112,7 @@ describe("index tests", function () {
       const event = {
           headers: {
               "x-pagopa-cx-taxid": taxId,
+              "x-pagopa-lollipop-user-id": taxId,
               "x-pagopa-pn-io-src": "QR_CODE" // Aggiunto per passare validateSourceDetails
           },
           methodArn: "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request"
@@ -141,7 +143,7 @@ describe("index tests", function () {
         mock.onPost(expectedUrl, taxId).reply(500);
 
         const event = {
-          headers: { "x-pagopa-cx-taxid": taxId },
+          headers: { "x-pagopa-cx-taxid": taxId, "x-pagopa-lollipop-user-id": taxId },
           methodArn: "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request"
         };
 
@@ -166,7 +168,7 @@ describe("index tests", function () {
         mock.onPost(expectedUrl, taxId).timeout();
 
         const event = {
-          headers: { "x-pagopa-cx-taxid": taxId },
+          headers: { "x-pagopa-cx-taxid": taxId, "x-pagopa-lollipop-user-id": taxId },
           methodArn: "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request"
         };
 


### PR DESCRIPTION
…er-id' e rimosso flusso bloccante su 'x-pagopa-cx-taxid'