### PR TITLE
fix(PN-20461): add basepath to oidc

### DIFF
--- a/oidc/README.md
+++ b/oidc/README.md
@@ -5,15 +5,15 @@ Lambda Node.js che implementa il flusso OIDC con One Identity per l'autenticazio
 ## Flusso
 
 ```text
-Frontend → GET /oidc-authorize → redirect a One Identity
-One Identity → POST /oidc-token → scambia il codice OIDC con un JWT SEND
+Frontend → GET /oidc/authorize → redirect a One Identity
+One Identity → POST /oidc/token → scambia il codice OIDC con un JWT SEND
 ```
 
-### GET /oidc-authorize
+### GET /oidc/authorize
 
 Riceve `idp` (obbligatorio), `aar` e `retrievalId` (opzionali) come query string. Genera `state` e `nonce` come UUID v4, li salva in Redis con TTL configurabile, e restituisce la URL di redirect verso One Identity.
 
-### POST /oidc-token
+### POST /oidc/token
 
 Riceve `code` e `state` (obbligatori, validati da API Gateway). Legge da Redis i dati associati allo `state` (`nonce`, `idp`, `aar`, `retrievalId`): se lo state non esiste risponde 400. Esegue la token exchange con One Identity, valida l'`id_token` usando il `nonce` letto da Redis, genera il JWT SEND e invalida la chiave Redis dello state. In caso di errore la chiave Redis viene comunque eliminata (nel `finally`).
 

--- a/oidc/src/app/index.ts
+++ b/oidc/src/app/index.ts
@@ -35,10 +35,10 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
   }
 
   const resource = event.resource;
-  if (resource === "/oidc-authorize") {
+  if (resource === "/authorize") {
     return oidcAuthorizeHandler(event, context);
   }
-  if (resource === "/oidc-token") {
+  if (resource === "/token") {
     return oidcTokenHandler(event, context);
   }
 

--- a/oidc/src/test/handlers/index.test.ts
+++ b/oidc/src/test/handlers/index.test.ts
@@ -53,7 +53,7 @@ describe("Main handler - Origin validation", () => {
   it("should return error when event has no origin", async () => {
     const eventWithoutOrigin = {
       ...mockTokenExchangeEvent,
-      resource: "/oidc-token",
+      resource: "/token",
       headers: { origin: undefined },
     };
 
@@ -78,7 +78,7 @@ describe("Main handler - Origin validation", () => {
 
     const eventWithInvalidOrigin = {
       ...mockTokenExchangeEvent,
-      resource: "/oidc-token",
+      resource: "/token",
       headers: { origin: "invalid-origin" },
     };
 

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -285,7 +285,7 @@ Parameters:
 
   OidcAuthorizeRedirectUri:
     Type: String
-    Description: 'Redirect URI for oidc-authorize endpoint'
+    Description: 'Redirect URI for authorize endpoint'
 
   OidcSecretName:
     Type: String
@@ -1708,11 +1708,12 @@ Resources:
     Type: AWS::ApiGateway::BasePathMapping
     Condition: EnableOidcApi
     Properties:
+      BasePath: "oidc"
       DomainName: !Ref WebApiDnsName
       RestApiId: !Ref OidcRestApi
       Stage: !Ref OidcRestApiStage
 
-  # Lambda access right for POST method (oidc-token)
+  # Lambda access right for POST method (token)
   OidcTokenLambdaPermission:
     Type: AWS::Lambda::Permission
     Condition: EnableOidcApi
@@ -1723,10 +1724,10 @@ Resources:
       FunctionName: !Ref OidcLambdaName
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OidcRestApi}/*/POST/oidc-token"
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OidcRestApi}/*/POST/token"
       SourceAccount: !Ref AWS::AccountId
 
-  # Lambda access right for GET method (oidc-authorize)
+  # Lambda access right for GET method (authorize)
   OidcAuthorizeLambdaPermission:
     Type: AWS::Lambda::Permission
     Condition: EnableOidcApi
@@ -1737,7 +1738,7 @@ Resources:
       FunctionName: !Ref OidcLambdaName
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OidcRestApi}/*/GET/oidc-authorize"
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OidcRestApi}/*/GET/authorize"
       SourceAccount: !Ref AWS::AccountId
 
   # Token Exchange OIDC Body model
@@ -1770,7 +1771,7 @@ Resources:
     Properties:
       RestApiId: !Ref OidcRestApi
       ParentId: !GetAtt OidcRestApi.RootResourceId
-      PathPart: "oidc-authorize"
+      PathPart: "authorize"
 
   OidcTokenResource:
     Type: AWS::ApiGateway::Resource
@@ -1778,9 +1779,9 @@ Resources:
     Properties:
       RestApiId: !Ref OidcRestApi
       ParentId: !GetAtt OidcRestApi.RootResourceId
-      PathPart: "oidc-token"
+      PathPart: "token"
 
-  # Token Exchange OIDC POST method (oidc-token)
+  # Token Exchange OIDC POST method (token)
   OidcTokenPostMethod:
     DependsOn: OidcLambda
     Type: AWS::ApiGateway::Method
@@ -1805,7 +1806,7 @@ Resources:
         ContentHandling: CONVERT_TO_TEXT
         TimeoutInMillis: 29000
 
-  # Token Exchange OIDC GET method (oidc-authorize)
+  # Token Exchange OIDC GET method (authorize)
   OidcAuthorizeGetMethod:
     DependsOn: OidcLambda
     Type: AWS::ApiGateway::Method
@@ -1837,7 +1838,7 @@ Resources:
       ValidateRequestBody: true
       ValidateRequestParameters: true
 
-  # Token Exchange OIDC OPTIONS method (oidc-token)
+  # Token Exchange OIDC OPTIONS method (token)
   OidcTokenOptionsMethod:
     DependsOn: OidcLambda
     Type: AWS::ApiGateway::Method
@@ -1872,7 +1873,7 @@ Resources:
             ResponseTemplates:
               "application/json": ""
 
-  # Token Exchange OIDC OPTIONS method (oidc-authorize)
+  # Token Exchange OIDC OPTIONS method (authorize)
   OidcAuthorizeOptionsMethod:
     DependsOn: OidcLambda
     Type: AWS::ApiGateway::Method


### PR DESCRIPTION
Added a custom-domain BasePath: "oidc" to the OidcAPIMapping (AWS::ApiGateway::BasePathMapping), so the OIDC API is no longer exposed at the domain root.