### PR TITLE
fix/jwtAuthorizer: console.warn on disconnect redis error

### DIFF
--- a/jwtAuthorizer/src/app/redis.js
+++ b/jwtAuthorizer/src/app/redis.js
@@ -22,7 +22,7 @@ const disconnectRedis = async () => {
   try {
     await RedisHandler.disconnectRedis();
   } catch (error) {
-    console.error("Error disconnecting from Redis:", error);
+    console.warn("Error disconnecting from Redis:", error);
   }
 };
 

--- a/webLogout/src/app/redis.js
+++ b/webLogout/src/app/redis.js
@@ -19,7 +19,7 @@ const disconnectRedis = async () => {
   try {
     await RedisHandler.disconnectRedis();
   } catch (error) {
-    console.error("Error disconnecting from Redis:", error);
+    console.warn("Error disconnecting from Redis:", error);
   }
 };
 


### PR DESCRIPTION
Use console.warn instead of console.error on redis disconnect error